### PR TITLE
Add export and repo details functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "embla-carousel-react": "^8.6.0",
+        "file-saver": "^2.0.5",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.525.0",
         "mantine-react-table": "^1.3.4",
@@ -64,6 +65,7 @@
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2",
+        "xlsx": "^0.18.5",
         "zod": "^4.0.5"
       },
       "devDependencies": {
@@ -4113,6 +4115,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4540,6 +4551,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4608,6 +4632,15 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color": {
@@ -4694,6 +4727,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -5819,6 +5864,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5926,6 +5977,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/function-bind": {
@@ -8558,6 +8618,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -9361,6 +9433,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9369,6 +9459,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "embla-carousel-react": "^8.6.0",
+    "file-saver": "^2.0.5",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.525.0",
     "mantine-react-table": "^1.3.4",
@@ -65,6 +66,7 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
+    "xlsx": "^0.18.5",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/src/app/[locale]/analysis/repos/[name]/page.tsx
+++ b/src/app/[locale]/analysis/repos/[name]/page.tsx
@@ -1,0 +1,10 @@
+import RepositoryDetails from '@/features/repositories/components/RepositoryDetails';
+
+export default async function RepoPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  return <RepositoryDetails repoName={name} />;
+}

--- a/src/app/api/repos/[name]/route.ts
+++ b/src/app/api/repos/[name]/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const org = process.env.GITHUB_ORG;
   const token = process.env.GITHUB_TOKEN;
   const apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com';
@@ -12,8 +12,8 @@ export async function GET() {
     );
   }
 
-  const endpoint = `${apiUrl}/orgs/${org}/repos`;
-  console.debug('Fetching repos from', endpoint);
+  const name = request.nextUrl.pathname.split('/').pop() ?? '';
+  const endpoint = `${apiUrl}/repos/${org}/${name}`;
   const res = await fetch(endpoint, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -24,13 +24,11 @@ export async function GET() {
 
   if (!res.ok) {
     return NextResponse.json(
-      { error: 'Failed to fetch repositories' },
+      { error: 'Failed to fetch repository' },
       { status: res.status }
     );
   }
 
   const data = await res.json();
-  console.debug('GitHub response status', res.status);
-  console.debug('GitHub response body', data);
   return NextResponse.json(data);
 }

--- a/src/features/repositories/components/RepositoryDetails.tsx
+++ b/src/features/repositories/components/RepositoryDetails.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useRepository } from "../hooks/useRepository";
+
+interface Props {
+  repoName: string;
+}
+
+export default function RepositoryDetails({ repoName }: Props) {
+  const { data: repo, isLoading, error } = useRepository(repoName);
+
+  if (isLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (error || !repo) {
+    return <div className="p-6 text-red-600">Error loading repository</div>;
+  }
+
+  return (
+    <div className="p-6">
+      <Card className="rounded-none border-2 border-gray-300 shadow-lg">
+        <CardHeader>
+          <CardTitle>{repo.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>{repo.description || "No description"}</p>
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <span>
+              <strong>Language:</strong> {repo.language || "Unknown"}
+            </span>
+            <span>
+              <strong>Visibility:</strong> {repo.private ? "Private" : "Public"}
+            </span>
+            <span>
+              <strong>Stars:</strong> {repo.stargazers_count}
+            </span>
+            <span>
+              <strong>Forks:</strong> {repo.forks_count}
+            </span>
+            <span>
+              <strong>Watchers:</strong> {repo.watchers_count}
+            </span>
+            <span>
+              <strong>Open Issues:</strong> {repo.open_issues_count}
+            </span>
+            <span>
+              <strong>Default Branch:</strong> {repo.default_branch}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/repositories/components/RepositoryTable.tsx
+++ b/src/features/repositories/components/RepositoryTable.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { useMemo } from "react";
+import { Link } from "@/i18n/navigation";
 import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
 import { useRepositories } from "../hooks/useRepositories";
 import type { GitHubRepo } from "../types/repository.types";
+import { exportToCsv, exportToXlsx } from "@/lib/exportUtils";
 
 export default function RepositoryTable() {
   const { data: repos, isLoading, error } = useRepositories();
@@ -31,14 +34,12 @@ export default function RepositoryTable() {
         header: "Repository Name",
         size: 250,
         Cell: ({ row }) => (
-          <a
-            href={row.original.html_url}
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            href={`/analysis/repos/${row.original.name}`}
             className="font-semibold text-blue-700 hover:text-blue-900 hover:underline transition-colors duration-200"
           >
             {row.original.name}
-          </a>
+          </Link>
         ),
       },
       {
@@ -251,6 +252,24 @@ export default function RepositoryTable() {
           <span className="text-xs text-gray-500">
             {table.getSelectedRowModel().rows.length > 0 && `${table.getSelectedRowModel().rows.length} selected`}
           </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              exportToCsv(table.getRowModel().rows.map((r) => r.original), 'repositories')
+            }
+          >
+            Export CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              exportToXlsx(table.getRowModel().rows.map((r) => r.original), 'repositories')
+            }
+          >
+            Export XLSX
+          </Button>
         </div>
       </div>
     ),

--- a/src/features/repositories/hooks/useRepositories.ts
+++ b/src/features/repositories/hooks/useRepositories.ts
@@ -6,5 +6,6 @@ export const useRepositories = () => {
   return useQuery<GitHubRepo[]>({
     queryKey: ['repositories'],
     queryFn: repositoryService.getRepositories,
+    staleTime: 3600 * 1000,
   });
 };

--- a/src/features/repositories/hooks/useRepository.ts
+++ b/src/features/repositories/hooks/useRepository.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { repositoryService } from '../services/repositoryService';
+import { GitHubRepoDetails } from '../types/repository.types';
+
+export const useRepository = (name: string) => {
+  return useQuery<GitHubRepoDetails>({
+    queryKey: ['repository', name],
+    queryFn: () => repositoryService.getRepository(name),
+    enabled: !!name,
+    staleTime: 3600 * 1000,
+  });
+};

--- a/src/features/repositories/services/repositoryService.ts
+++ b/src/features/repositories/services/repositoryService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { GitHubRepo } from '../types/repository.types';
+import { GitHubRepo, GitHubRepoDetails } from '../types/repository.types';
 
 const getRepositories = async (): Promise<GitHubRepo[]> => {
   const response = await axios.get<GitHubRepo[]>('/api/repos');
@@ -7,4 +7,10 @@ const getRepositories = async (): Promise<GitHubRepo[]> => {
   return response.data;
 };
 
-export const repositoryService = { getRepositories };
+const getRepository = async (name: string): Promise<GitHubRepoDetails> => {
+  const response = await axios.get<GitHubRepoDetails>(`/api/repos/${name}`);
+  console.debug('Repository fetched', response.data);
+  return response.data;
+};
+
+export const repositoryService = { getRepositories, getRepository };

--- a/src/features/repositories/types/repository.types.ts
+++ b/src/features/repositories/types/repository.types.ts
@@ -8,3 +8,12 @@ export interface GitHubRepo {
   created_at: string;
   updated_at: string;
 }
+
+export interface GitHubRepoDetails extends GitHubRepo {
+  full_name: string;
+  stargazers_count: number;
+  watchers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  default_branch: string;
+}

--- a/src/lib/exportUtils.ts
+++ b/src/lib/exportUtils.ts
@@ -1,0 +1,21 @@
+import { utils, writeFile } from 'xlsx';
+
+export function exportToXlsx<T extends object>(data: T[], fileName: string) {
+  const worksheet = utils.json_to_sheet(data);
+  const workbook = utils.book_new();
+  utils.book_append_sheet(workbook, worksheet, 'Data');
+  writeFile(workbook, fileName.endsWith('.xlsx') ? fileName : `${fileName}.xlsx`);
+}
+
+export function exportToCsv<T extends object>(data: T[], fileName: string) {
+  const worksheet = utils.json_to_sheet(data);
+  const csv = utils.sheet_to_csv(worksheet);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = fileName.endsWith('.csv') ? fileName : `${fileName}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}


### PR DESCRIPTION
## Summary
- add CSV and XLSX export utilities
- implement export buttons in repository table
- link repository names to internal details pages
- cache repository queries for one hour
- fetch single repository via new API route
- show repository details on dedicated page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872a1e265d4832ea21b4757e8b9f80b