### PR TITLE
Add projects listing

### DIFF
--- a/src/app/[locale]/analysis/projects/page.tsx
+++ b/src/app/[locale]/analysis/projects/page.tsx
@@ -1,0 +1,9 @@
+import ProjectsTable from '@/features/projects/components/ProjectsTable';
+
+export default function ProjectsPage() {
+  return (
+    <div className="">
+      <ProjectsTable />
+    </div>
+  );
+}

--- a/src/app/[locale]/analysis/repos/[name]/projects/page.tsx
+++ b/src/app/[locale]/analysis/repos/[name]/projects/page.tsx
@@ -1,0 +1,10 @@
+import ProjectsTable from '@/features/projects/components/ProjectsTable';
+
+export default async function RepoProjectsPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  return <ProjectsTable repoName={name} />;
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -12,18 +12,18 @@ export async function GET() {
     );
   }
 
-  const endpoint = `${apiUrl}/orgs/${org}/repos`;
+  const endpoint = `${apiUrl}/orgs/${org}/projects`;
   const res = await fetch(endpoint, {
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
+      Accept: 'application/vnd.github.inertia-preview+json',
     },
     next: { revalidate: 3600 },
   });
 
   if (!res.ok) {
     return NextResponse.json(
-      { error: 'Failed to fetch repositories' },
+      { error: 'Failed to fetch projects' },
       { status: res.status }
     );
   }

--- a/src/app/api/repos/[name]/projects/route.ts
+++ b/src/app/api/repos/[name]/projects/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const org = process.env.GITHUB_ORG;
   const token = process.env.GITHUB_TOKEN;
   const apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com';
@@ -12,18 +12,20 @@ export async function GET() {
     );
   }
 
-  const endpoint = `${apiUrl}/orgs/${org}/repos`;
+  const segments = request.nextUrl.pathname.split('/');
+  const repo = segments[segments.indexOf('repos') + 1] || '';
+  const endpoint = `${apiUrl}/repos/${org}/${repo}/projects`;
   const res = await fetch(endpoint, {
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
+      Accept: 'application/vnd.github.inertia-preview+json',
     },
     next: { revalidate: 3600 },
   });
 
   if (!res.ok) {
     return NextResponse.json(
-      { error: 'Failed to fetch repositories' },
+      { error: 'Failed to fetch projects' },
       { status: res.status }
     );
   }

--- a/src/features/projects/components/ProjectsTable.tsx
+++ b/src/features/projects/components/ProjectsTable.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useMemo } from "react";
+import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
+import { useProjects } from "../hooks/useProjects";
+import type { GitHubProject } from "../types/project.types";
+import { exportToCsv, exportToXlsx } from "@/lib/exportUtils";
+
+interface Props {
+  repoName?: string;
+}
+
+export default function ProjectsTable({ repoName }: Props) {
+  const {
+    data: projects,
+    isLoading,
+    error,
+  } = useProjects(repoName);
+
+  const columns = useMemo<MRT_ColumnDef<GitHubProject>[]>(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Project Name",
+        size: 250,
+      },
+      {
+        accessorKey: "body",
+        header: "Description",
+        size: 400,
+        Cell: ({ cell }) => (
+          <span className="text-gray-700 text-sm leading-relaxed">
+            {cell.getValue<string>() ?? (
+              <span className="text-gray-400 italic">No description</span>
+            )}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "state",
+        header: "State",
+        size: 120,
+      },
+      {
+        accessorKey: "html_url",
+        header: "Project URL",
+        size: 300,
+        Cell: ({ cell }) => (
+          <a
+            href={cell.getValue<string>()}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 text-sm truncate block"
+          >
+            {cell.getValue<string>()}
+          </a>
+        ),
+      },
+      {
+        accessorKey: "created_at",
+        header: "Created",
+        size: 120,
+        Cell: ({ cell }) => {
+          const date = new Date(cell.getValue<string>());
+          return (
+            <span className="text-sm text-gray-600">
+              {date.toLocaleDateString()}
+            </span>
+          );
+        },
+        filterVariant: "date-range",
+        sortingFn: "datetime",
+      },
+      {
+        accessorKey: "updated_at",
+        header: "Last Updated",
+        size: 120,
+        Cell: ({ cell }) => {
+          const date = new Date(cell.getValue<string>());
+          return (
+            <span className="text-sm text-gray-600">
+              {date.toLocaleDateString()}
+            </span>
+          );
+        },
+        filterVariant: "date-range",
+        sortingFn: "datetime",
+      },
+    ],
+    []
+  );
+
+  const table = useMantineReactTable({
+    columns,
+    data: projects ?? [],
+    enableColumnFilters: true,
+    enableGlobalFilter: true,
+    enableSorting: true,
+    enablePagination: true,
+    enableRowSelection: true,
+    enableColumnResizing: true,
+    enableDensityToggle: true,
+    enableFullScreenToggle: true,
+    enableHiding: true,
+    initialState: {
+      pagination: { pageSize: 10, pageIndex: 0 },
+      density: "md",
+    },
+    paginationDisplayMode: "pages",
+    positionToolbarAlertBanner: "bottom",
+    state: {
+      isLoading,
+      showAlertBanner: !!error,
+    },
+    renderTopToolbarCustomActions: ({ table }) => (
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-8 bg-blue-600 rounded-none"></div>
+          <span className="text-xl font-bold text-gray-800">
+            {repoName ? `Projects of ${repoName}` : "GitHub Projects"}
+          </span>
+        </div>
+        <span className="text-sm font-normal text-gray-500 bg-white px-3 py-1 border-2 border-gray-300 rounded-none">
+          {projects?.length || 0} projects
+        </span>
+        <div className="flex items-center gap-2 ml-auto">
+          <span className="text-xs text-gray-500">
+            {table.getSelectedRowModel().rows.length > 0 &&
+              `${table.getSelectedRowModel().rows.length} selected`}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              exportToCsv(
+                table.getRowModel().rows.map((r) => r.original),
+                "projects"
+              )
+            }
+          >
+            Export CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              exportToXlsx(
+                table.getRowModel().rows.map((r) => r.original),
+                "projects"
+              )
+            }
+          >
+            Export XLSX
+          </Button>
+        </div>
+      </div>
+    ),
+  });
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-lg text-red-600">Error loading projects</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-full mx-auto p-6">
+      <Card className="rounded-none border-2 border-gray-300 shadow-lg">
+        <CardContent className="p-0">
+          <div className="overflow-hidden">
+            <MantineReactTable table={table} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/projects/hooks/useProjects.ts
+++ b/src/features/projects/hooks/useProjects.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { projectService } from '../services/projectService';
+import { GitHubProject } from '../types/project.types';
+
+export const useProjects = (repo?: string) => {
+  return useQuery<GitHubProject[]>({
+    queryKey: repo ? ['repoProjects', repo] : ['projects'],
+    queryFn: () =>
+      repo
+        ? projectService.getRepoProjects(repo)
+        : projectService.getProjects(),
+    enabled: repo ? !!repo : true,
+    staleTime: 3600 * 1000,
+  });
+};

--- a/src/features/projects/services/projectService.ts
+++ b/src/features/projects/services/projectService.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { GitHubProject } from '../types/project.types';
+
+const getProjects = async (): Promise<GitHubProject[]> => {
+  const response = await axios.get<GitHubProject[]>('/api/projects');
+  return response.data;
+};
+
+const getRepoProjects = async (repo: string): Promise<GitHubProject[]> => {
+  const response = await axios.get<GitHubProject[]>(`/api/repos/${repo}/projects`);
+  return response.data;
+};
+
+export const projectService = { getProjects, getRepoProjects };

--- a/src/features/projects/types/project.types.ts
+++ b/src/features/projects/types/project.types.ts
@@ -1,0 +1,9 @@
+export interface GitHubProject {
+  id: number;
+  name: string;
+  body: string | null;
+  state: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/features/repositories/components/RepositoryDetails.tsx
+++ b/src/features/repositories/components/RepositoryDetails.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
 import { useRepository } from "../hooks/useRepository";
 
 interface Props {
@@ -48,6 +50,13 @@ export default function RepositoryDetails({ repoName }: Props) {
             <span>
               <strong>Default Branch:</strong> {repo.default_branch}
             </span>
+          </div>
+          <div className="pt-4">
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/analysis/repos/${repo.name}/projects`}>
+                View Projects
+              </Link>
+            </Button>
           </div>
         </CardContent>
       </Card>

--- a/src/features/repositories/services/repositoryService.ts
+++ b/src/features/repositories/services/repositoryService.ts
@@ -3,13 +3,11 @@ import { GitHubRepo, GitHubRepoDetails } from '../types/repository.types';
 
 const getRepositories = async (): Promise<GitHubRepo[]> => {
   const response = await axios.get<GitHubRepo[]>('/api/repos');
-  console.debug('Repositories fetched', response.data);
   return response.data;
 };
 
 const getRepository = async (name: string): Promise<GitHubRepoDetails> => {
   const response = await axios.get<GitHubRepoDetails>(`/api/repos/${name}`);
-  console.debug('Repository fetched', response.data);
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
- implement API routes for projects
- list projects at `/analysis/projects` and inside each repo
- add export and download capabilities for projects table
- link repository pages to their projects
- remove debug console logs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872cd75422c832eba2ebcf3e1333327