### PR TITLE
Add contributor detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Planique isn’t just a project dashboard. It’s an open canvas for clarity, co
 
     - Commits, PRs, Issues, Reviews per user over a time range.
     - Export: Leaderboard
+    - Detailed view at `/users/[username]` with downloadable reports
 
 19. **User Activity Heatmap**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,8 @@
         "embla-carousel-react": "^8.6.0",
         "file-saver": "^2.0.5",
         "input-otp": "^1.4.2",
+        "jspdf": "^3.0.1",
+        "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.525.0",
         "mantine-react-table": "^1.3.4",
         "next": "15.3.5",
@@ -3562,6 +3564,13 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -3581,6 +3590,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.36.0",
@@ -4415,6 +4431,18 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4484,6 +4512,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4506,6 +4544,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/busboy": {
@@ -4596,6 +4646,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -4759,6 +4829,18 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4800,6 +4882,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -5130,6 +5222,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -5897,6 +5999,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6318,6 +6426,20 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -6920,6 +7042,33 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+      "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7909,6 +8058,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8024,6 +8180,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -8260,6 +8426,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -8335,6 +8508,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/run-parallel": {
@@ -8683,6 +8866,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -8895,6 +9088,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
@@ -8944,6 +9147,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -9337,6 +9550,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vaul": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "embla-carousel-react": "^8.6.0",
     "file-saver": "^2.0.5",
     "input-otp": "^1.4.2",
+    "jspdf": "^3.0.1",
+    "jspdf-autotable": "^5.0.2",
     "lucide-react": "^0.525.0",
     "mantine-react-table": "^1.3.4",
     "next": "15.3.5",

--- a/src/app/[locale]/users/[username]/page.tsx
+++ b/src/app/[locale]/users/[username]/page.tsx
@@ -1,0 +1,10 @@
+import UserContributions from '@/features/user-contributions/components/UserContributions';
+
+export default async function UserPage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+  return <UserContributions username={username} />;
+}

--- a/src/app/api/users/[username]/contributions/route.ts
+++ b/src/app/api/users/[username]/contributions/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const token = process.env.GITHUB_TOKEN;
+  const org = process.env.GITHUB_ORG;
+  const apiUrl = 'https://api.github.com/graphql';
+
+  if (!token || !org) {
+    return NextResponse.json({ error: 'GitHub configuration missing' }, { status: 500 });
+  }
+
+  const username = request.nextUrl.pathname.split('/').filter(Boolean).pop() || '';
+  const searchParams = request.nextUrl.searchParams;
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  // Get organization ID
+  const orgQuery = {
+    query: `query($login: String!) { organization(login: $login) { id } }`,
+    variables: { login: org },
+  };
+
+  const orgRes = await fetch(apiUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(orgQuery),
+  });
+
+  if (!orgRes.ok) {
+    return NextResponse.json({ error: 'Failed to fetch organization' }, { status: orgRes.status });
+  }
+
+  const orgData = await orgRes.json();
+  const orgId = orgData.data.organization.id;
+
+  const contributionsQuery = {
+    query: `
+      query($login: String!, $orgId: ID!, $from: DateTime, $to: DateTime) {
+        user(login: $login) {
+          avatarUrl
+          url
+          contributionsCollection(organizationID: $orgId, from: $from, to: $to) {
+            commitContributionsByRepository(maxRepositories: 100) {
+              repository { name url }
+              contributions(first: 1) { totalCount }
+            }
+            issueContributions(first: 1) { totalCount }
+            pullRequestContributions(first: 1) { totalCount }
+            pullRequestReviewContributions(first: 1) { totalCount }
+            contributionCalendar {
+              weeks {
+                contributionDays { date contributionCount }
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: { login: username, orgId, from, to },
+  };
+
+  const res = await fetch(apiUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(contributionsQuery),
+  });
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to fetch contributions' }, { status: res.status });
+  }
+
+  const data = await res.json();
+  const user = data.data.user;
+  return NextResponse.json(user);
+}

--- a/src/features/user-contributions/components/UserContributions.tsx
+++ b/src/features/user-contributions/components/UserContributions.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useUserContributions } from "../hooks/useUserContributions";
+import type { RepoContribution, ContributionDay } from "../types/contributions.types";
+import { exportToCsv, exportToXlsx, exportToPdf } from "@/lib/exportUtils";
+
+interface Props {
+  username: string;
+}
+
+export default function UserContributions({ username }: Props) {
+  const [range, setRange] = useState<string>("7");
+  const [customFrom, setCustomFrom] = useState<string>("");
+  const [customTo, setCustomTo] = useState<string>("");
+
+  const now = new Date();
+  const fromDate = (() => {
+    if (range === "custom" && customFrom) return new Date(customFrom);
+    if (range === "30") return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  })();
+  const toDate = range === "custom" && customTo ? new Date(customTo) : now;
+
+  const fromIso = fromDate.toISOString();
+  const toIso = toDate.toISOString();
+
+  const { data, isLoading, error } = useUserContributions(username, fromIso, toIso);
+
+  const commits = data?.contributionsCollection.commitContributionsByRepository ?? [];
+  const columns = [
+    {
+      accessorKey: "repository.name",
+      header: "Repository",
+      Cell: ({ row }: { row: { original: RepoContribution } }) => (
+        <Link href={row.original.repository.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">
+          {row.original.repository.name}
+        </Link>
+      ),
+    },
+    {
+      accessorKey: "contributions.totalCount",
+      header: "Commits",
+    },
+  ] as MRT_ColumnDef<RepoContribution>[];
+
+  const table = useMantineReactTable({
+    columns,
+    data: commits,
+    state: { isLoading, showAlertBanner: !!error },
+    enablePagination: true,
+    initialState: { pagination: { pageSize: 10, pageIndex: 0 } },
+    renderTopToolbarCustomActions: ({ table }) => (
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 ml-auto">
+          <Button variant="outline" size="sm" onClick={() => exportToCsv(table.getRowModel().rows.map(r => r.original), `contributions_${username}`)}>CSV</Button>
+          <Button variant="outline" size="sm" onClick={() => exportToXlsx(table.getRowModel().rows.map(r => r.original), `contributions_${username}`)}>XLSX</Button>
+          <Button variant="outline" size="sm" onClick={() => exportToPdf(table.getRowModel().rows.map(r => r.original), `contributions_${username}`)}>PDF</Button>
+        </div>
+      </div>
+    ),
+  });
+
+  const issueCount = data?.contributionsCollection.issueContributions.totalCount ?? 0;
+  const prCount = data?.contributionsCollection.pullRequestContributions.totalCount ?? 0;
+  const reviewCount = data?.contributionsCollection.pullRequestReviewContributions.totalCount ?? 0;
+
+  const timeline: ContributionDay[] = [];
+  data?.contributionsCollection.contributionCalendar.weeks.forEach(w => {
+    w.contributionDays.forEach(d => timeline.push(d));
+  });
+
+  const timelineColumns = [
+    { accessorKey: "date", header: "Date" },
+    { accessorKey: "contributionCount", header: "Commits" },
+  ] as MRT_ColumnDef<ContributionDay>[];
+
+  const timelineTable = useMantineReactTable({
+    columns: timelineColumns,
+    data: timeline,
+    enablePagination: true,
+    initialState: { pagination: { pageSize: 7, pageIndex: 0 } },
+  });
+
+  if (error) {
+    return <div className="p-6 text-red-600">Error loading contributions</div>;
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-4">
+        {data && (
+          <Image src={data.avatarUrl} alt="avatar" width={48} height={48} className="rounded-full" />
+        )}
+        <Link href={data?.url || `https://github.com/${username}`} target="_blank" className="text-xl font-bold text-blue-600">
+          {username}
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <select value={range} onChange={e => setRange(e.target.value)} className="w-40 border rounded-md p-2 text-sm">
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="custom">Custom</option>
+        </select>
+        {range === "custom" && (
+          <div className="flex items-center gap-2">
+            <Input type="date" value={customFrom} onChange={e => setCustomFrom(e.target.value)} />
+            <Input type="date" value={customTo} onChange={e => setCustomTo(e.target.value)} />
+          </div>
+        )}
+      </div>
+
+      <Card className="rounded-none border-2 border-gray-300 shadow-lg">
+        <CardHeader>
+          <CardTitle>Contributions Summary</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>Issues: {issueCount}</p>
+          <p>Pull Requests: {prCount}</p>
+          <p>Code Reviews: {reviewCount}</p>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-none border-2 border-gray-300 shadow-lg">
+        <CardHeader>
+          <CardTitle>Commits by Repository</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <MantineReactTable table={table} />
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-none border-2 border-gray-300 shadow-lg">
+        <CardHeader>
+          <CardTitle>Commits Timeline</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <MantineReactTable table={timelineTable} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/user-contributions/hooks/useUserContributions.ts
+++ b/src/features/user-contributions/hooks/useUserContributions.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { contributionsService } from '../services/contributionsService';
+import { UserContributions } from '../types/contributions.types';
+
+export const useUserContributions = (
+  username: string,
+  from?: string,
+  to?: string
+) => {
+  return useQuery<UserContributions>({
+    queryKey: ['userContributions', username, from, to],
+    queryFn: () => contributionsService.getUserContributions(username, from, to),
+    enabled: !!username,
+    staleTime: 3600 * 1000,
+    gcTime: 7200 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+};

--- a/src/features/user-contributions/services/contributionsService.ts
+++ b/src/features/user-contributions/services/contributionsService.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { UserContributions } from '../types/contributions.types';
+
+export const contributionsService = {
+  getUserContributions: async (
+    username: string,
+    from?: string,
+    to?: string
+  ): Promise<UserContributions> => {
+    const params = new URLSearchParams();
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    const url = `/api/users/${username}/contributions?${params.toString()}`;
+    const response = await axios.get<UserContributions>(url);
+    return response.data;
+  },
+};

--- a/src/features/user-contributions/types/contributions.types.ts
+++ b/src/features/user-contributions/types/contributions.types.ts
@@ -1,0 +1,28 @@
+export interface RepoContribution {
+  repository: {
+    name: string;
+    url: string;
+  };
+  contributions: {
+    totalCount: number;
+  };
+}
+
+export interface ContributionDay {
+  date: string;
+  contributionCount: number;
+}
+
+export interface UserContributions {
+  avatarUrl: string;
+  url: string;
+  contributionsCollection: {
+    commitContributionsByRepository: RepoContribution[];
+    issueContributions: { totalCount: number };
+    pullRequestContributions: { totalCount: number };
+    pullRequestReviewContributions: { totalCount: number };
+    contributionCalendar: {
+      weeks: { contributionDays: ContributionDay[] }[];
+    };
+  };
+}

--- a/src/features/users/components/UserTable.tsx
+++ b/src/features/users/components/UserTable.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/ui/avatar";
 import Image from "next/image";
+import Link from "next/link";
 import { useMemo } from "react";
 import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
 import { useUsers } from "../hooks/useUsers";
@@ -32,9 +33,9 @@ export default function UserTable() {
         header: "Username",
         size: 200,
         Cell: ({ row }) => (
-          <a href={row.original.html_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">
+          <Link href={`./${row.original.login}`} className="text-blue-600 hover:text-blue-800">
             {row.original.login}
-          </a>
+          </Link>
         ),
       },
       {

--- a/src/lib/exportUtils.ts
+++ b/src/lib/exportUtils.ts
@@ -19,3 +19,17 @@ export function exportToCsv<T extends object>(data: T[], fileName: string) {
   document.body.removeChild(link);
   URL.revokeObjectURL(link.href);
 }
+
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+export function exportToPdf<T extends object>(data: T[], fileName: string) {
+  if (!data.length) return;
+  const doc = new jsPDF();
+  const headers = Object.keys(data[0]);
+  const rows = data.map(item =>
+    headers.map(h => String((item as Record<string, unknown>)[h] ?? ''))
+  );
+  autoTable(doc, { head: [headers], body: rows });
+  doc.save(fileName.endsWith('.pdf') ? fileName : `${fileName}.pdf`);
+}


### PR DESCRIPTION
## Summary
- add dependencies for PDF export
- provide `exportToPdf` helper
- link usernames to a new user detail page
- implement user contributions feature
- expose `/api/users/[username]/contributions` endpoint
- document the user detail page in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874e3e70b00832e92af420ffda6ebaa